### PR TITLE
Fix producer timestamp docs

### DIFF
--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -505,7 +505,7 @@ static PyMethodDef Producer_methods[] = {
 	  "  :param func on_delivery(err,msg): Delivery report callback to call "
 	  "(from :py:func:`poll()` or :py:func:`flush()`) on successful or "
 	  "failed delivery\n"
-          "  :param int timestamp: Message timestamp (CreateTime) in microseconds since epoch UTC (requires librdkafka >= v0.9.4, api.version.request=true, and broker >= 0.10.0.0). Default value is current time.\n"
+          "  :param int timestamp: Message timestamp (CreateTime) in milliseconds since epoch UTC (requires librdkafka >= v0.9.4, api.version.request=true, and broker >= 0.10.0.0). Default value is current time.\n"
 	  "\n"
 	  "  :rtype: None\n"
 	  "  :raises BufferError: if the internal producer message queue is "


### PR DESCRIPTION
The producer timestamp is documented as being in microseconds but is actually expected to be milliseconds.  It is passed to `rd_kafka_producev` as-is and that function documents it as milliseconds.  Just to make sure I looked at the implementation of `rd_kafka_producev` and that puts the timestamp in the Kafka message unmodified.  The Kafka docs say that timestamp is in milliseconds.